### PR TITLE
feat: Initialize game board with cells and mines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,131 @@
 version = 4
 
 [[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
 name = "n-dimensional-minesweeper"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,4 @@ repository = "https://github.com/example/n-dimensional-minesweeper" # Example re
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Future dependencies will go here.
-# For example, a random number generator for placing mines:
-# rand = "0.8"
+rand = "0.8"

--- a/src/board.rs
+++ b/src/board.rs
@@ -8,6 +8,9 @@
 //! - Calculating the number of adjacent mines for each cell.
 //! - Handling the logic for revealing cells.
 
+use crate::cell::{Cell, CellKind};
+use rand::seq::SliceRandom;
+
 // The Board struct will represent the N-dimensional game board.
 pub struct Board {
     /// The dimensions of the board (e.g., `vec![10, 10]` for a 2D 10x10 board).
@@ -16,7 +19,7 @@ pub struct Board {
     /// The cells of the board, stored in a flat vector.
     /// The mapping from N-dimensional coordinates to a 1D index is a key part
     /// of this implementation.
-    // cells: Vec<Cell>,
+    pub cells: Vec<Cell>,
 
     /// The total number of mines on the board.
     num_mines: usize,
@@ -30,11 +33,30 @@ impl Board {
     /// * `dimensions` - A vector defining the size of each dimension.
     /// * `num_mines` - The number of mines to place.
     pub fn new(dimensions: Vec<usize>, num_mines: usize) -> Self {
-        // TODO: Initialize the cells and place the mines.
+        // Calculate the total number of cells.
+        let total_cells = dimensions.iter().product();
+
+        // Create the cells.
+        let mut cells = vec![Cell::new(); total_cells];
+
+        // Place the mines.
+        Self::place_mines(&mut cells, num_mines);
+
         Self {
             dimensions,
-            // cells: Vec::new(),
+            cells,
             num_mines,
+        }
+    }
+
+    /// Places mines randomly on the board.
+    fn place_mines(cells: &mut Vec<Cell>, num_mines: usize) {
+        let mut rng = rand::thread_rng();
+        let mine_indices = (0..cells.len()).collect::<Vec<usize>>();
+        let chosen_indices = mine_indices.choose_multiple(&mut rng, num_mines);
+
+        for &index in chosen_indices {
+            cells[index].kind = CellKind::Mine;
         }
     }
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -5,15 +5,17 @@
 //! Each cell can be in various states, and can either be a mine or be empty.
 
 // The Cell struct represents a single cell on the board.
+#[derive(Clone, Debug)]
 pub struct Cell {
     /// The state of the cell.
-    state: CellState,
+    pub state: CellState,
 
     /// The kind of the cell (mine or empty).
-    kind: CellKind,
+    pub kind: CellKind,
 }
 
 // CellState represents the visibility of a cell.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CellState {
     /// The cell is hidden from the player.
     Hidden,
@@ -24,6 +26,7 @@ pub enum CellState {
 }
 
 // CellKind represents the content of a cell.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CellKind {
     /// The cell is a mine.
     Mine,


### PR DESCRIPTION
This commit introduces the basic structure for the game board.

- Adds a `cells: Vec<Cell>` field to the `Board` struct to hold the state of each cell on the board.
- Implements the `Board::new` function to initialize the board with a given set of dimensions and number of mines.
- Adds a `place_mines` helper function to randomly distribute mines across the board.
- Adds the `rand` crate as a dependency for random number generation.
- Updates the `Cell` struct to derive `Clone` and `Debug` traits and makes its fields public to allow modification from the `board` module.