### PR TITLE
feat: Calculate adjacent mine counts

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -9,6 +9,7 @@
 //! - Handling the logic for revealing cells.
 
 use crate::cell::{Cell, CellKind};
+use crate::coordinates::{get_neighbors, to_coords, to_index};
 use rand::seq::SliceRandom;
 
 // The Board struct will represent the N-dimensional game board.
@@ -42,10 +43,39 @@ impl Board {
         // Place the mines.
         Self::place_mines(&mut cells, num_mines);
 
-        Self {
+        let mut board = Self {
             dimensions,
             cells,
             num_mines,
+        };
+
+        board.calculate_adjacent_mines();
+        board
+    }
+
+    /// Calculates and sets the number of adjacent mines for each empty cell.
+    fn calculate_adjacent_mines(&mut self) {
+        for i in 0..self.cells.len() {
+            // We only need to calculate for empty cells
+            if self.cells[i].kind == CellKind::Mine {
+                continue;
+            }
+
+            let coords = to_coords(i, &self.dimensions);
+            let neighbors = get_neighbors(&coords, &self.dimensions);
+
+            let mut mine_count = 0;
+            for neighbor_coords in neighbors {
+                let neighbor_index = to_index(&neighbor_coords, &self.dimensions);
+                if self.cells[neighbor_index].kind == CellKind::Mine {
+                    mine_count += 1;
+                }
+            }
+
+            // Update the cell's kind with the mine count
+            if let CellKind::Empty { adjacent_mines } = &mut self.cells[i].kind {
+                *adjacent_mines = mine_count;
+            }
         }
     }
 
@@ -58,5 +88,56 @@ impl Board {
         for &index in chosen_indices {
             cells[index].kind = CellKind::Mine;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::{Cell, CellKind};
+
+    #[test]
+    fn test_calculate_adjacent_mines_2d() {
+        let dimensions = vec![3, 3];
+        let total_cells = 9;
+        let mut cells = vec![Cell::new(); total_cells];
+
+        // Place mines at (0,0) [index 0] and (2,2) [index 8]
+        cells[0].kind = CellKind::Mine;
+        cells[8].kind = CellKind::Mine;
+
+        let mut board = Board {
+            dimensions,
+            cells,
+            num_mines: 2,
+        };
+
+        board.calculate_adjacent_mines();
+
+        // Check adjacent mine counts for a few cells
+        // Cell (1,0) [index 1] should have 1 neighbor mine.
+        if let CellKind::Empty { adjacent_mines } = board.cells[1].kind {
+            assert_eq!(adjacent_mines, 1);
+        } else {
+            panic!("Cell (1,0) should be empty");
+        }
+
+        // Cell (0,1) [index 3] should have 1 neighbor mine.
+        if let CellKind::Empty { adjacent_mines } = board.cells[3].kind {
+            assert_eq!(adjacent_mines, 1);
+        } else {
+            panic!("Cell (0,1) should be empty");
+        }
+
+        // Cell (1,1) [index 4] should have 2 neighbor mines.
+        if let CellKind::Empty { adjacent_mines } = board.cells[4].kind {
+            assert_eq!(adjacent_mines, 2);
+        } else {
+            panic!("Cell (1,1) should be empty");
+        }
+
+        // Ensure mine cells are untouched
+        assert_eq!(board.cells[0].kind, CellKind::Mine);
+        assert_eq!(board.cells[8].kind, CellKind::Mine);
     }
 }

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -59,5 +59,125 @@ pub fn to_coords(mut index: usize, dimensions: &[usize]) -> Coordinates {
     coords
 }
 
-// TODO: Add a function to get the neighbors of a cell in N-dimensional space.
-// This will involve iterating through all combinations of (-1, 0, 1) for each dimension.
+/// Returns a list of valid neighbor coordinates for a given cell.
+///
+/// This function explores all adjacent cells in an N-dimensional grid. An adjacent
+/// cell is one that can be reached by changing each coordinate by -1, 0, or 1.
+/// The function excludes the cell's own coordinates from the result.
+///
+/// # Arguments
+///
+/// * `coords` - The N-dimensional coordinates of the cell.
+/// * `dimensions` - The dimensions of the board.
+///
+/// # Returns
+///
+/// A `Vec<Coordinates>` containing the coordinates of all valid neighbors.
+pub fn get_neighbors(coords: &Coordinates, dimensions: &[usize]) -> Vec<Coordinates> {
+    let mut neighbors = Vec::new();
+    let num_dimensions = coords.len();
+    if num_dimensions == 0 {
+        return neighbors;
+    }
+
+    let num_neighbors_to_check = 3_u32.pow(num_dimensions as u32);
+    let center_index = (num_neighbors_to_check - 1) / 2;
+
+    'outer: for i in 0..num_neighbors_to_check {
+        if i == center_index {
+            continue;
+        }
+
+        let mut temp_coords = coords.clone();
+        let mut n = i;
+
+        for j in 0..num_dimensions {
+            let offset = (n % 3) as i32 - 1;
+            n /= 3;
+
+            // Check for underflow before applying the offset
+            if offset == -1 && temp_coords[j] == 0 {
+                continue 'outer;
+            }
+
+            let new_coord = (temp_coords[j] as i32 + offset) as usize;
+
+            // Check for overflow
+            if new_coord >= dimensions[j] {
+                continue 'outer;
+            }
+
+            temp_coords[j] = new_coord;
+        }
+
+        neighbors.push(temp_coords);
+    }
+
+    neighbors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_neighbors_2d_center() {
+        let dimensions = vec![3, 3];
+        let coords = vec![1, 1];
+        let mut neighbors = get_neighbors(&coords, &dimensions);
+        neighbors.sort(); // Sort for consistent comparison
+
+        let mut expected = vec![
+            vec![0, 0], vec![0, 1], vec![0, 2],
+            vec![1, 0],             vec![1, 2],
+            vec![2, 0], vec![2, 1], vec![2, 2],
+        ];
+        expected.sort();
+
+        assert_eq!(neighbors, expected);
+    }
+
+    #[test]
+    fn test_get_neighbors_2d_corner() {
+        let dimensions = vec![3, 3];
+        let coords = vec![0, 0];
+        let mut neighbors = get_neighbors(&coords, &dimensions);
+        neighbors.sort();
+        let mut expected = vec![vec![0, 1], vec![1, 0], vec![1, 1]];
+        expected.sort();
+        assert_eq!(neighbors, expected);
+    }
+
+    #[test]
+    fn test_get_neighbors_2d_edge() {
+        let dimensions = vec![3, 3];
+        let coords = vec![0, 1];
+        let mut neighbors = get_neighbors(&coords, &dimensions);
+        neighbors.sort();
+        let mut expected = vec![
+            vec![0, 0], vec![0, 2],
+            vec![1, 0], vec![1, 1], vec![1, 2],
+        ];
+        expected.sort();
+        assert_eq!(neighbors, expected);
+    }
+
+    #[test]
+    fn test_get_neighbors_1d() {
+        let dimensions = vec![3];
+        let coords = vec![1];
+        let mut neighbors = get_neighbors(&coords, &dimensions);
+        neighbors.sort();
+        let mut expected = vec![vec![0], vec![2]];
+        expected.sort();
+        assert_eq!(neighbors, expected);
+    }
+
+    #[test]
+    fn test_get_neighbors_3d_center() {
+        let dimensions = vec![3, 3, 3];
+        let coords = vec![1, 1, 1];
+        let neighbors = get_neighbors(&coords, &dimensions);
+        assert_eq!(neighbors.len(), 26);
+    }
+}


### PR DESCRIPTION
This commit implements the logic to calculate the number of mines adjacent to each empty cell on the board.

- Adds a `get_neighbors` function in `src/coordinates.rs` to find all valid neighbors for a cell in N-dimensional space.
- Implements `calculate_adjacent_mines` in `src/board.rs` to iterate through all cells and count neighboring mines, storing the result in each `CellKind::Empty`.
- Adds comprehensive unit tests for both `get_neighbors` and the mine counting logic to ensure correctness.